### PR TITLE
Change the bundle cache path on gh-actions

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      GEMS_PATH: ~/vendor/bundle
+      GEMS_PATH: vendor/bundle
 
     steps:
       - name: Checkout


### PR DESCRIPTION
A [fix](https://github.com/cotes2020/jekyll-theme-chirpy/commit/063c3b94991a2edfba64a8146377a6a73533c291) for not deploying related with ubuntu issue